### PR TITLE
Add class name to table body wrapper.

### DIFF
--- a/src/FixedDataTableBufferedRows.react.js
+++ b/src/FixedDataTableBufferedRows.react.js
@@ -163,7 +163,7 @@ var FixedDataTableBufferedRows = React.createClass({
       props.firstRowOffset - firstRowPosition + props.offsetTop
     );
 
-    return <div style={style}>{this._staticRowArray}</div>;
+    return <div className={cx('fixedDataTable/body')} style={style}>{this._staticRowArray}</div>;
   },
 
   _getRowHeight(/*number*/ index) /*number*/ {


### PR DESCRIPTION
In some situations its hard to target (in CSS) row/cell in body without using ":not()" selectors.